### PR TITLE
Misc updates

### DIFF
--- a/consensus/init-bc1.sh
+++ b/consensus/init-bc1.sh
@@ -6,7 +6,7 @@ apk add curl
 
 echo "** ethiab ** Initializing Lodestar Beacon"
 
-node ./packages/cli/bin/lodestar beacon \
+exec node ./packages/cli/bin/lodestar beacon \
   --execution.urls "http://172.16.8.2:8551" \
   --jwt-secret "/root/data/execution/1/geth/jwtsecret" \
   --dataDir "/root/data/consensus/1" \

--- a/consensus/init-bc1.sh
+++ b/consensus/init-bc1.sh
@@ -6,7 +6,7 @@ apk add curl
 
 echo "** ethiab ** Initializing Lodestar Beacon"
 
-exec node ./packages/cli/bin/lodestar beacon \
+exec node --max-old-space-size=4096 ./packages/cli/bin/lodestar beacon \
   --execution.urls "http://172.16.8.2:8551" \
   --jwt-secret "/root/data/execution/1/geth/jwtsecret" \
   --dataDir "/root/data/consensus/1" \

--- a/consensus/init-bc2.sh
+++ b/consensus/init-bc2.sh
@@ -10,7 +10,7 @@ echo "** ethiab ** enr: $enr"
 
 echo "** ethiab ** Initializing Lodestar Beacon"
 
-node ./packages/cli/bin/lodestar beacon \
+exec node ./packages/cli/bin/lodestar beacon \
   --execution.urls "http://172.16.8.3:8551" \
   --jwt-secret "/root/data/execution/2/geth/jwtsecret" \
   --dataDir "/root/data/consensus/2" \

--- a/consensus/init-bc2.sh
+++ b/consensus/init-bc2.sh
@@ -10,7 +10,7 @@ echo "** ethiab ** enr: $enr"
 
 echo "** ethiab ** Initializing Lodestar Beacon"
 
-exec node ./packages/cli/bin/lodestar beacon \
+exec node --max-old-space-size=4096 ./packages/cli/bin/lodestar beacon \
   --execution.urls "http://172.16.8.3:8551" \
   --jwt-secret "/root/data/execution/2/geth/jwtsecret" \
   --dataDir "/root/data/consensus/2" \

--- a/execution/init-ec1.sh
+++ b/execution/init-ec1.sh
@@ -8,5 +8,5 @@ geth init \
 
 echo "** ethiab ** Starting geth"
 
-geth \
+exec geth \
   --config /root/execution/ec1.toml "$@"

--- a/execution/init-ec2.sh
+++ b/execution/init-ec2.sh
@@ -24,5 +24,5 @@ sed -i '/BootstrapNodes/,/BootstrapNodesV5/s|\[.*\]|['"${enode}"']|' /root/execu
 
 echo "** ethiab ** Starting geth"
 
-geth \
+exec geth \
   --config /root/execution/ec2.toml "$@"


### PR DESCRIPTION
Just a few minor things I noticed while reviewing

- Increases max old memory space to 4096, this might not be required for test net nodes as state and data to process is way smaller but Lodestar isn't really tested without this flag, I don't know the exact numbers on when it would cause issues if the flag is not set so might be better to just set it to be on the safe side.
- `exec` processes to make sure they are PID 1 and receive signal such as `SIGTERM` when container is shutting down. This speeds up shutdown time and let's process run cleanup tasks.
- ~~Added `--nat` flag as there have been issues before running inside docker while setting `enr.ip`, https://github.com/ChainSafe/lodestar/issues/5397~~